### PR TITLE
Update PDF Manual URL so that it does not 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to replace the earlier
 system. 
 
 The full PLOVER codebook is available in the repo
-[above](https://github.com/openeventdata/PLOVER/blob/master/PLOVER_Manual.pdf),
+[above](https://github.com/openeventdata/PLOVER/blob/master/PLOVER_MANUAL.pdf),
 and a short introduction to PLOVER and event data is below.
 
 There is currently a near-real-time PLOVER-coded global event data set on Dataverse at https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/AJGVIT. Extensive details are available at these two open-access papers:


### PR DESCRIPTION
I noticed that the URL to the PDF version of the manual referenced in the readme was 404ing on a few different browsers. This was resolved when I capitalized the file name. 